### PR TITLE
Dockerize development environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:14-alpine
+FROM python:3.10-alpine
+
+RUN mkdir /project
+
+RUN apk add --update npm
+
+RUN pip install poetry
+
+COPY docker_entrypoint.sh /entrypoint.sh
+
+RUN chmod +x /entrypoint.sh
+
+CMD /entrypoint.sh

--- a/README.rst
+++ b/README.rst
@@ -33,14 +33,25 @@ You will need to specify the ``FONTAWESOME_NPM_AUTH_TOKEN`` environment variable
 before installing Node dependenvies. You should be using ``direnv`` locally for
 secret management and encryption. Ask for this token, it's private.
 
-You need to be using Node<=14 and at least Python 3.6+, but Python 3.10 is
-preferred. Using ``asdf`` is recommended here. With both configured, you can
-install all the dependencies with:
+You need to be using Node<=14 and Python 3.10.
+Using ``asdf`` is a great option for adding Python 3.10 to a system that doesn't have it. 
+h both configured, you can install all the dependencies with:
 
 .. code-block:: console
 
     $ poetry install
     $ npm install
+
+Running in Docker
+~~~~~~~~~~~~~~~~~
+
+If you have Docker with docker-compose available, you can run a local development server like this:
+
+.. code-block:: console
+
+    $ # invoke direnv to add secret environment
+    $ docker-compose build  # builds the server
+    $ docker-compose up 
 
 Local development and authoring
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+version: '3'
+
+volumes:
+  build:
+
+services:
+
+  server:
+    # Image used for all the other services (proxito, web, celery, build)
+    build:
+      context: ${PWD}
+      dockerfile: ./Dockerfile
+    environment:
+      - FONTAWESOME_NPM_AUTH_TOKEN=${FONTAWESOME_NPM_AUTH_TOKEN}
+    ports:
+      - "8000:8000"
+    volumes:
+      - ${PWD}/:/project

--- a/docker_entrypoint.sh
+++ b/docker_entrypoint.sh
@@ -1,0 +1,3 @@
+cd /project
+poetry install
+npm install


### PR DESCRIPTION
* [ ] Install all dependencies runtime
* [ ] Install all dependencies in Docker container
* [ ] Install all dependencies in Docker container, but update runtime
* [ ] Invoke dev server in entrypoint
* [ ] Write good docs

I noticed that the Poetry configuration refuses to install on Python 3.9 so I updated the docs to reflect this.
