### PR TITLE
Remove team link, it's part of Company page

### DIFF
--- a/readthedocs_theme/templates/includes/footer.html
+++ b/readthedocs_theme/templates/includes/footer.html
@@ -49,7 +49,6 @@
             {% block menu_about %}
               <h4 class="ui sub header">About us</h4>
               <a class="item" href="{{ SITEURL }}/company/">Company</a>
-              <a class="item" href="https://docs.readthedocs.io/page/team.html">Team</a>
               <a class="item" href="https://dev.readthedocs.io/page/contribute.html">Contributing</a>
               <h4 class="ui sub header">Tools</h4>
               <a class="item" href="/tools/sphinx/">Sphinx</a>


### PR DESCRIPTION
Upcoming documentation changes are removing Team members from the Team page. Although it still exists [here](https://docs.readthedocs.io/en/latest/team.html), it seems weird to click that link and then not see the team. So maybe it's best to remove it and then we'll maybe later add some more info or reference on the Company page.

<!-- readthedocs-preview read-the-docs-site-community start -->
----
:books: Documentation preview :books:: https://read-the-docs-site-community--183.com.readthedocs.build/

<!-- readthedocs-preview read-the-docs-site-community end -->