### PR TITLE
Add platform URL for community/business on log in menus

### DIFF
--- a/readthedocs_theme/templates/includes/topnav.html
+++ b/readthedocs_theme/templates/includes/topnav.html
@@ -47,11 +47,20 @@
   <a class="item" data-analytics="community-login" href="https://readthedocs.org/dashboard/">
     <i class="fad fa-people-group primary icon"></i>
     Read the Docs Community
+
+    <p class="ui mini grey text">
+      <code>https://readthedocs.org</code>
+    </p>
   </a>
   <a class="item" data-analytics="commercial-login" href="https://readthedocs.com/dashboard/">
     <i class="fad fa-building secondary icon"></i>
     Read the Docs for Business
+
+    <p class="ui mini grey text">
+      <code>https://readthedocs.com</code>
+    </p>
   </a>
+  <div class="ui divider"></div>
   <a class="item" href="{{ SITE_URL }}/about/">
     <i class="fad fa-circle-question grey icon"></i>
     Learn more


### PR DESCRIPTION
This adds a URL below the descriptive name to add a little more context
for the menu items.

Closes #198

<!-- readthedocs-preview read-the-docs-website start -->
----
:books: Documentation preview :books:: https://read-the-docs-website--200.com.readthedocs.build/

<!-- readthedocs-preview read-the-docs-website end -->