### PR TITLE
Fancy pricing page CTA

### DIFF
--- a/content/partials/pricing.html
+++ b/content/partials/pricing.html
@@ -66,7 +66,7 @@
 {% macro feature_table() %}
   <table class="ui mini unstackable celled table" id="feature-table">
 
-    {% macro _feature_table_row() %}
+    {% macro _feature_table_header() %}
       <tr>
         <th class="eight wide" scope="col"></th>
         {% if show_community_features %}
@@ -85,15 +85,29 @@
         </th>
       </tr>
     {% endmacro %}
+  
+    {% macro _feature_table_footer() %}
+      <tr>
+        <th class="eight wide" scope="col"></th>
+        {% if show_community_features %}
+          <th class="two wide center aligned" scope="col">
+            <a class="ui teal button" href="./#/community">Sign up</a>
+          </th>
+        {% endif %}
+        <th class="six wide center aligned" scope="col" colspan="3">
+          <a class="ui violet button" href="./#/business/pro">Sign up</a>
+        </th>
+      </tr>
+    {% endmacro %}
 
     <thead class="ui sticky" data-module="sticky" data-module-context="#feature-table">
-      {{ _feature_table_row() }}
+      {{ _feature_table_header() }}
     </thead>
     <tbody>
       {{ caller() }}
     </tbody>
     <tfoot>
-      {{ _feature_table_row() }}
+      {{ _feature_table_footer() }}
     </tfoot>
   </table>
 {% endmacro %}


### PR DESCRIPTION
I also tried to make the CTAs at the bottom of the pricing table link directly to a signup,
but got some weird CSS glitches.
When the header rows "detach" from the table, they shift in width that doesn't match the table:

<img width="1124" alt="Screenshot 2023-08-01 at 1 52 06 PM" src="https://github.com/readthedocs/website/assets/25510/a890ef7b-8585-4885-b904-6355f70c49e6">


<!-- readthedocs-preview read-the-docs-website start -->
----
:books: Documentation preview :books:: https://read-the-docs-website--212.com.readthedocs.build/

<!-- readthedocs-preview read-the-docs-website end -->