### PR TITLE
Some fixes for the front page header changes

### DIFF
--- a/content/pages/homepage.html
+++ b/content/pages/homepage.html
@@ -42,10 +42,10 @@
                 {% block homepage_callout %}
                   <div class="ui large left aligned basic vertical segment">
                     <h1 class="ui huge header">
-                      Documentation Simplified
+                      Documentation simplified
                     </h1>
                     <p>
-                      Build, host, and share documentation in seconds
+                      Build, host, and share documentation, all with a single platform.
                     </p>
 
                     {% block homepage_callout_buttons %}


### PR DESCRIPTION
Some leftovers from #211. Fixes capitalization to match our other
headers and puts the focus not on time but on our service.

I've had this feedback on other similar CTAs. Focusing on
minutes/seconds is saying our value is that we save time. That's not
wrong, but we don't exactly aim to save time, but rather our value is
that we manage all of the hurdles with infrastructure when building and
hosting authed/searchable/etc docs.

Both versions here could also use more content, as it looks less good, and quite sparse, with only two lines of text:

![image](https://github.com/readthedocs/website/assets/1140183/be3e4d60-f62e-4902-b100-ce6ea35e2c41)

<!-- readthedocs-preview read-the-docs-website start -->
----
:books: Documentation preview :books:: https://read-the-docs-website--214.com.readthedocs.build/

<!-- readthedocs-preview read-the-docs-website end -->