### PR TITLE
Hack to use 404 error page in RTD

### DIFF
--- a/content/pages/errors/404.html
+++ b/content/pages/errors/404.html
@@ -3,7 +3,9 @@
     <title>Not found</title>
     <meta name="subtitle" content="The resource you requested is not recognized" />
     <meta name="template" content="error" />
-    <meta name="slug" content="errors/404" />
+    {# The path for 404 pages is not flexible and needs to be top-level #}
+    {# <meta name="slug" content="errors/404" /> #}
+    <meta name="slug" content="404" />
     <meta name="status" content="hidden" />
     <meta name="icon" content="fa-radar" />
     <meta name="icon_style" content="--fa-primary-color: greenyellow;" />


### PR DESCRIPTION
I opened https://github.com/readthedocs/readthedocs.org/issues/10622 to
consider making this configurable. The other error status codes are not
supported by RTD yet.

- Closes #111
- Refs https://github.com/readthedocs/readthedocs.org/issues/10622

<!-- readthedocs-preview read-the-docs-website start -->
----
:books: Documentation preview :books:: https://read-the-docs-website--220.com.readthedocs.build/

<!-- readthedocs-preview read-the-docs-website end -->