### PR TITLE
Improve buttons in sign up modal

### DIFF
--- a/readthedocs_theme/templates/includes/topnav.html
+++ b/readthedocs_theme/templates/includes/topnav.html
@@ -266,7 +266,8 @@
     </div>
 
     <div class="actions">
-      <a href="{{ SITE_URL }}/features/" class="ui cancel button">Learn more</a>
+      <a href="{{ SITE_URL }}/choosing-a-platform/" class="ui cancel button"><i class="fad fa-circle-question grey icon" aria-hidden="true"></i>Choosing a platform</a>
+      <a href="{{ SITE_URL }}/features/" class="ui cancel button"><i class="fad fa-sparkles grey icon" aria-hidden="true"></i>Explore all the features</a>
     </div>
   </div>
 {% endblock signup_modal %}


### PR DESCRIPTION
I found that the signup modal doesn't link to the "Choosing a platform" page, which I think it's important in that context. The modal shows small differences between the two sites, but I felt there was some context missing there. I added a link to this page so users can dig deeper if they want to.

Besides, I changed the copy from "Learn more" to "Explore all the features", that communicates exactly what that button is for.

Finally, I added icons to these buttons because they make everything to look better.

<!-- readthedocs-preview read-the-docs-website start -->
----
:books: Documentation preview :books:: https://read-the-docs-website--228.com.readthedocs.build/

<!-- readthedocs-preview read-the-docs-website end -->

This is how it looks with these changes:

![Screenshot_2023-09-08_12-55-32](https://github.com/readthedocs/website/assets/244656/bc145a85-6489-4ea8-9e47-f6a8ddef2b56)
