### PR TITLE
Docusaurus: fix `build.commands` indent

### DIFF
--- a/content/includes/try-it-out-docusaurus.html
+++ b/content/includes/try-it-out-docusaurus.html
@@ -25,17 +25,17 @@
                 nodejs: "18"
                 # You can also specify other tool versions:
                 # python: "3"
-            commands:
-                # "docs/" was created following the Docusaurus tutorial:
-                # npx create-docusaurus@latest docs classic
-                #
-                # Install Docusaurus dependencies
-                - cd docs/ && npm install
-                # Build the site
-                - cd docs/ && npm run build
-                # Copy generated files into Read the Docs directory
-                - mkdir --parents $READTHEDOCS_OUTPUT/html/
-                - cp --recursive docs/build/* $READTHEDOCS_OUTPUT/html/
+              commands:
+                  # "docs/" was created following the Docusaurus tutorial:
+                  # npx create-docusaurus@latest docs classic
+                  #
+                  # Install Docusaurus dependencies
+                  - cd docs/ && npm install
+                  # Build the site
+                  - cd docs/ && npm run build
+                  # Copy generated files into Read the Docs directory
+                  - mkdir --parents $READTHEDOCS_OUTPUT/html/
+                  - cp --recursive docs/build/* $READTHEDOCS_OUTPUT/html/
             ```
 
             {% endmarkdown %}


### PR DESCRIPTION
`commands` was at the same level then `build` when it should be nested.

<!-- readthedocs-preview read-the-docs-website start -->
----
:books: Documentation preview :books:: https://read-the-docs-website--231.com.readthedocs.build/

<!-- readthedocs-preview read-the-docs-website end -->