### PR TITLE
A small grammar fix on the Cloudflare comparison page

### DIFF
--- a/content/pages/comparisons/cloudflare-pages.html
+++ b/content/pages/comparisons/cloudflare-pages.html
@@ -20,7 +20,7 @@
     header="Read the Docs is the <em><strong>all-in-one</strong></em> solution you're looking for your documentation")
     %}
     <p>
-      Cloudflare Pages is great for hosting SPA (<em>Single Page Applications</em>) for frontend developers.
+      Cloudflare Pages is great for hosting SPA (<em>single-page applications</em>) for frontend developers.
       However, when talking about <strong>technical writers</strong> and <strong>documentation projects</strong>,
       Read the Docs is <em>the</em> perfect solution.
     </p>
@@ -72,7 +72,7 @@
               </h2>
 
               <p>
-                Cloudflare Pages is a great product, but it's more thought for deploying SPA (Single Page Applications) with fewer options for documentation sites.
+                Cloudflare Pages is a great product, but it's more thought for deploying SPA (single-page applications) with fewer options for documentation sites.
                 For publishing great documentation <strong>without having to build the features yourself</strong>,
                 Read the Docs is the <em>all-in-one solution</em> that provides everything you need out of the box!
               </p>


### PR DESCRIPTION
The term behind SPA isn't a proper noun so it doesn't need title case.
It's most commonly hyphenated as well.

<!-- readthedocs-preview read-the-docs-website start -->
----
:books: Documentation preview :books:: https://read-the-docs-website--232.com.readthedocs.build/

<!-- readthedocs-preview read-the-docs-website end -->