### PR TITLE
Remove "authentic" since it's not useful

### DIFF
--- a/content/pages/docs-as-code.html
+++ b/content/pages/docs-as-code.html
@@ -98,7 +98,7 @@
                 </span>
               </a>
 
-              {%- set header_5 = "Read the Docs authentic flyout" %}
+              {%- set header_5 = "Read the Docs flyout" %}
               {%- set icon_5 = "fa-bars" -%}
               <a href="#flyout" class="ui small header item">
                 <i class="fad {{ icon_5 }} secondary big icon"></i>
@@ -212,7 +212,7 @@
       {% call about.step(
           header=header_5,
           image="/images/docs-as-code/flyout.png",
-          image_alt="Read the Docs authentic flyout",
+          image_alt="Read the Docs flyout",
           icon=icon_5) %}
       {% markdown %}
       Let your users select between **multiple versions and translations** of your documentation in a quick way using the flyout menu.


### PR DESCRIPTION
Related https://github.com/readthedocs/website/pull/194#discussion_r1323644313

<!-- readthedocs-preview read-the-docs-website start -->
----
:books: Documentation preview :books:: https://read-the-docs-website--233.com.readthedocs.build/

<!-- readthedocs-preview read-the-docs-website end -->