### PR TITLE
GitBook: visualize edits from external collaborators

### DIFF
--- a/content/pages/comparisons/gitbook.html
+++ b/content/pages/comparisons/gitbook.html
@@ -42,7 +42,7 @@
     {{ comparison.feature_row("Redirects", "Redirect users to the right page", "fa-arrows-turn-right", on_other=True) }}
     {{ comparison.feature_row("Translations", "Serve translated versions of your docs", "fa-language", on_other=True) }}
     {{ comparison.feature_row("Private documention", "Give access only to trusted people", "fa-lock", on_other=True) }}
-    {{ comparison.feature_row("Deploy previews from forked repositories", "Visualize edits from external collaborators", "fa-people-group") }}
+    {{ comparison.feature_row("Preview changes from forked repositories", "Visualize edits from external collaborators", "fa-people-group") }}
     {{ comparison.feature_row("Static hosting", "Publish any static content", "fa-page") }}
     {{ comparison.feature_row("Visual diff on deploy previews", "Visualize differences directly on the rendered version", "fa-face-monocle") }}
     {{ comparison.feature_row("Custom 404 pages", "Style 404 pages with context-related information", "fa-xmark") }}

--- a/content/pages/comparisons/gitbook.html
+++ b/content/pages/comparisons/gitbook.html
@@ -42,6 +42,7 @@
     {{ comparison.feature_row("Redirects", "Redirect users to the right page", "fa-arrows-turn-right", on_other=True) }}
     {{ comparison.feature_row("Translations", "Serve translated versions of your docs", "fa-language", on_other=True) }}
     {{ comparison.feature_row("Private documention", "Give access only to trusted people", "fa-lock", on_other=True) }}
+    {{ comparison.feature_row("Deploy previews from forked repositories", "Visualize edits from external collaborators", "fa-people-group") }}
     {{ comparison.feature_row("Static hosting", "Publish any static content", "fa-page") }}
     {{ comparison.feature_row("Visual diff on deploy previews", "Visualize differences directly on the rendered version", "fa-face-monocle") }}
     {{ comparison.feature_row("Custom 404 pages", "Style 404 pages with context-related information", "fa-xmark") }}


### PR DESCRIPTION
We do support PRs from forked repositories in a secure way.

<!-- readthedocs-preview read-the-docs-website start -->
----
:books: Documentation preview :books:: https://read-the-docs-website--238.com.readthedocs.build/

<!-- readthedocs-preview read-the-docs-website end -->