### PR TITLE
Remove "We updated our website!" callout

### DIFF
--- a/content/pages/homepage.html
+++ b/content/pages/homepage.html
@@ -14,21 +14,6 @@
     {% import "partials/technical.html" as technical %}
 
     {% block homepage_notification %}
-      <div class="ui padded container">
-        {# This is a temporary, hard coded notification. Only shown on the homepage as it is not dismissable. #}
-        <div class="ui info small center aligned message">
-          <i class="fad fa-sparkles icon"></i>
-          <a href="https://blog.readthedocs.com/website-migration/" target="_blank">
-            <strong>
-              We updated our website! 
-            </strong>
-            <span>
-              You can read more about what has changed on our blog.
-            </span>
-          </a>
-          <i class="fad fa-sparkles icon"></i>
-        </div>
-      </div>
     {% endblock homepage_notification %}
 
     {% block homepage_callout_wrapper %}


### PR DESCRIPTION
It's been a while since we updated it,
so I think we're safe to remove it.

We should put something similar to this on the beta dashboard though,
to alert folks to info about the beta.


<!-- readthedocs-preview read-the-docs-website start -->
----
📚 Documentation preview 📚: https://read-the-docs-website--240.com.readthedocs.build/

<!-- readthedocs-preview read-the-docs-website end -->