### PR TITLE
Fix change to commercial callout

### DIFF
--- a/content/pages/pricing.html
+++ b/content/pages/pricing.html
@@ -193,7 +193,7 @@
 
               <div class="sixteen wide tablet twelve wide computer middle aligned column">
                 <i class="fad fa-briefcase icon"></i>
-                Host <b>private projects</b> with Read the Docs for Business.
+                Host <b>commercial and private projects</b> with Read the Docs for Business.
               </div>
 
               <div class="sixteen wide tablet four wide computer column">


### PR DESCRIPTION
In #243 this was changed, but it now implies projects have to be private on commercial.
This reverts the change, and reuses terms we are already using on the
page: "private and commercial documentation/projects".

https://github.com/readthedocs/website/pull/243/files#r1457943722

<!-- readthedocs-preview read-the-docs-website start -->
----
📚 Documentation preview 📚: https://read-the-docs-website--245.com.readthedocs.build/

<!-- readthedocs-preview read-the-docs-website end -->