### PR TITLE
Add Feb 2024 newsletter

### DIFF
--- a/content/posts/newsletter-february-2024.md
+++ b/content/posts/newsletter-february-2024.md
@@ -1,13 +1,14 @@
 title: Read the Docs Newsletter - February 2024
-date: Jan 1, 2024
+date: Feb 1, 2024
 description: Company updates and new features from the last month, current focus, and upcoming features.
 category: Newsletter
-tags: newsletter, community, build-in-public
+tags: newsletter, community
 authors: Eric Holscher
 status: published
 
 ## News and updates
 
+* Forced redirects are now available for all users, but redirects are limited based on plan types. This is an update from our previous newsletter that comes from our redirects refactor.
 * We moved our new blog posts to be published on our website, so going forward you can find it [directly on our website](https://about.readthedocs.org/blog/).
 * We shipped an update that allows [Sphinx builds to share environments](https://github.com/readthedocs/readthedocs.org/pull/11073). This should make builds of multiple formats faster.
 * We shipped a few different security fixes that were found by Santos Gallegos, a member of our team. You can read more about them in our [security advisories](https://github.com/readthedocs/readthedocs.org/security/advisories)
@@ -18,11 +19,15 @@ You can always see the latest changes to our platforms in our [changelog 📃](h
 ## Upcoming changes
 
 - We continue to work on improving Addons. Our goal is to default all projects to using Addons in Q2 of 2024. We are working on improving the user experience, and adding more Addons to make the transition easier.
+- Our marketing website continues to get some updates. We are working on improving the user experience and making it easier to find the information you need.
+- Our Commercial beta dashboard is almost ready for public beta. We are working on the final touches and hope to have it available for all users soon.
+- We continue to work on improvements to our build system, [including support for "latest"](https://github.com/readthedocs/readthedocs.org/issues/8861) versions.
 
 Want to follow along with our development progress? View our [development roadmap 📍️](https://github.com/orgs/readthedocs/projects/156/views/1)
 
 ## Possible issues
 
+- If you are using an old version of our `readthedocs-sphinx-search` extension, you should upgrade it. You can read more in our [security notice](https://github.com/readthedocs/readthedocs-sphinx-search/security/advisories/GHSA-xgfm-fjx6-62mj).
 - We are investigating [removing support for VCS systems other than Git](https://github.com/readthedocs/readthedocs.org/issues/8840). We have sent an email to all users who are using other VCS systems for feedback as a first step.
 - We have [defaulted traffic analytics off](https://github.com/readthedocs/readthedocs.org/pull/11056) for users of our new Addons. This default is to save on resources for projects that aren't looking at our analytics data.
 - Our [beta dashboard](https://beta.readthedocs.org/) continues to be tested in public beta, and new functionality for Addons configuration is only be available in that new interface.

--- a/content/posts/newsletter-february-2024.md
+++ b/content/posts/newsletter-february-2024.md
@@ -1,0 +1,32 @@
+title: Read the Docs Newsletter - February 2024
+date: Jan 1, 2024
+description: Company updates and new features from the last month, current focus, and upcoming features.
+category: Newsletter
+tags: newsletter, community, build-in-public
+authors: Eric Holscher
+status: published
+
+## News and updates
+
+* We moved our new blog posts to be published on our website, so going forward you can find it [directly on our website](https://about.readthedocs.org/blog/).
+* We shipped an update that allows [Sphinx builds to share environments](https://github.com/readthedocs/readthedocs.org/pull/11073). This should make builds of multiple formats faster.
+* We shipped a few different security fixes that were found by Santos Gallegos, a member of our team. You can read more about them in our [security advisories](https://github.com/readthedocs/readthedocs.org/security/advisories)
+* We shipped an [updated settings page for Addons](https://github.com/readthedocs/readthedocs.org/pull/11031) in our new beta dashboard. This allows enabling and disabling each addon.
+
+You can always see the latest changes to our platforms in our [changelog 📃](https://docs.readthedocs.io/page/changelog.html).
+
+## Upcoming changes
+
+- We continue to work on improving Addons. Our goal is to default all projects to using Addons in Q2 of 2024. We are working on improving the user experience, and adding more Addons to make the transition easier.
+
+Want to follow along with our development progress? View our [development roadmap 📍️](https://github.com/orgs/readthedocs/projects/156/views/1)
+
+## Possible issues
+
+- We are investigating [removing support for VCS systems other than Git](https://github.com/readthedocs/readthedocs.org/issues/8840). We have sent an email to all users who are using other VCS systems for feedback as a first step.
+- We have [defaulted traffic analytics off](https://github.com/readthedocs/readthedocs.org/pull/11056) for users of our new Addons. This default is to save on resources for projects that aren't looking at our analytics data.
+- Our [beta dashboard](https://beta.readthedocs.org/) continues to be tested in public beta, and new functionality for Addons configuration is only be available in that new interface.
+
+-----
+
+Questions? Comments? Ideas for the next newsletter? [Contact us](mailto:hello@readthedocs.org)!

--- a/content/posts/newsletter-february-2024.md
+++ b/content/posts/newsletter-february-2024.md
@@ -13,6 +13,7 @@ status: published
 * We shipped an update that allows [Sphinx builds to share environments](https://github.com/readthedocs/readthedocs.org/pull/11073). This should make builds of multiple formats faster.
 * We shipped a few different security fixes that were found by Santos Gallegos, a member of our team. You can read more about them in our [security advisories](https://github.com/readthedocs/readthedocs.org/security/advisories)
 * We shipped an [updated settings page for Addons](https://github.com/readthedocs/readthedocs.org/pull/11031) in our new beta dashboard. This allows enabling and disabling each addon.
+* We updated our `build.tools` versions to use the Node.js for latest LTS version (`v20.11.0`) and added support for Go 1.21 and Rust 1.75.
 
 You can always see the latest changes to our platforms in our [changelog 📃](https://docs.readthedocs.io/page/changelog.html).
 

--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -1,6 +1,5 @@
 """Read the Docs website Pelican configuration."""
 
-import os
 
 AUTHOR = 'Read the Docs, Inc'
 SITENAME = 'Read the Docs'
@@ -38,13 +37,12 @@ PLUGINS = ['related_posts', 'jinja2content', 'readthedocs_theme.plugins.html_dir
 
 # Feed (RSS/Atom) settings
 FEED_DOMAIN = SITEURL
-FEED_RSS = FEED_RSS_URL = "blog/feed.rss"
-FEED_ATOM = FEED_ATOM_URL = "blog/atom.xml"
+FEED_ATOM = "blog/atom.xml"
+FEED_RSS = "blog/feed.rss"
 FEED_MAX_ITEMS = 1
-FEED_ALL_ATOM = None
-CATEGORY_FEED_ATOM = None
-TRANSLATION_FEED_ATOM = None
-AUTHOR_FEED_ATOM = None
+FEED_ALL_ATOM = None  # No translation
+TRANSLATION_FEED_ATOM = None  # No translation
+AUTHOR_FEED_ATOM = None  # No per author feed
 AUTHOR_FEED_RSS = None
 
 # Menu settings

--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -37,8 +37,8 @@ PLUGINS = ['related_posts', 'jinja2content', 'readthedocs_theme.plugins.html_dir
 
 # Feed (RSS/Atom) settings
 FEED_DOMAIN = SITEURL
-FEED_ATOM = "blog/atom.xml"
-FEED_RSS = "blog/feed.rss"
+FEED_ATOM = "feeds/atom.xml"
+FEED_RSS = "feeds/feed.rss"
 FEED_MAX_ITEMS = 1
 FEED_ALL_ATOM = None  # No translation
 TRANSLATION_FEED_ATOM = None  # No translation

--- a/readthedocs_theme/templates/includes/footer.html
+++ b/readthedocs_theme/templates/includes/footer.html
@@ -8,7 +8,7 @@
           <div class="ui vertical inverted text menu">
             {% block menu_news %}
               <h4 class="ui sub header">Stay updated</h4>
-              <a class="item" href="https://blog.readthedocs.com/">Blog</a>
+              <a class="item" href="https://about.readthedocs.org/blog/">Blog</a>
               <a class="item" href="https://landing.mailerlite.com/webforms/landing/t0a9l4">Newsletter</a>
               <a class="item" href="https://status.readthedocs.com/">Status</a>
               <div class="item">

--- a/readthedocs_theme/templates/includes/topnav.html
+++ b/readthedocs_theme/templates/includes/topnav.html
@@ -1,6 +1,7 @@
 {% macro menu_main() %}
   <a class="item{% if page and page.slug == 'features' %} active" aria-current="page{% endif %}" href="{{ SITEURL }}/features/">Features</a>
   <a class="item{% if page and page.slug == 'pricing' %} active" aria-current="page{% endif %}" href="{{ SITEURL }}/pricing/">Pricing</a>
+  <a class="item{% if page and 'blog' in page.slug %} active" aria-current="page{% endif %}" href="{{ SITEURL }}/blog/">Blog</a>
 {% endmacro %}
 
 {% macro menu_help() %}
@@ -65,7 +66,7 @@
   </a>
   <a class="item" href="/choosing-a-platform/">
     <i class="fad fa-circle-question grey icon"></i>
-    Choosing a platform 
+    Choosing a platform
   </a>
 {% endmacro %}
 

--- a/readthedocs_theme/templates/index.html
+++ b/readthedocs_theme/templates/index.html
@@ -75,7 +75,7 @@
               <div class="item">
                 <i class="fad fa-feed icon"></i>
                 <div class="content">
-                  Subscribe to <a href="/blog/feed.rss">our RSS feed</a> or <a href="/blog/atom.xml" target="_blank">our Atom feed</a> with your favorite reader.
+                  Subscribe to <a href="/feeds/feed.rss">our RSS feed</a> or <a href="/feeds/atom.xml" target="_blank">our Atom feed</a> with your favorite reader.
                 </div>
               </div>
               <div class="item">


### PR DESCRIPTION
This swaps this content over for our website blog,
and makes that the official place for writing new blog content!

* Blog post: https://read-the-docs-website--247.com.readthedocs.build/blog/2024/01/read-the-docs-newsletter-february-2024/
* Atom feed: https://read-the-docs-website--247.com.readthedocs.build/blog/atom.xml

<!-- readthedocs-preview read-the-docs-website start -->
----
📚 Documentation preview 📚: https://read-the-docs-website--247.com.readthedocs.build/

<!-- readthedocs-preview read-the-docs-website end -->