### PR TITLE
Drop spurious feeds in base template

### DIFF
--- a/readthedocs_theme/templates/base.html
+++ b/readthedocs_theme/templates/base.html
@@ -51,8 +51,6 @@
     #}
     <script src="https://kit.fontawesome.com/53af4251af.js" crossorigin="anonymous"></script>
 
-    <link href="{{ SITEURL }}/{{ FEED }}" type="application/atom+xml" rel="alternate" title="{{ SITENAME }} ATOM Feed" />
-    <link href="{{ SITEURL }}/{{ FEED_RSS }}" type="application/atom+xml" rel="alternate" title="{{ SITENAME }} RSS Feed" />
     <script src="{{ SITEURL }}/theme/js/vendor.js"></script>
     <script src="{{ SITEURL }}/theme/js/site.js"></script>
   {% endblock head %}


### PR DESCRIPTION
The feeds look correct to me:

![image](https://github.com/readthedocs/website/assets/1140183/a886231a-a70c-473b-a9b3-2455dbc01feb)

<!-- readthedocs-preview read-the-docs-website start -->
----
📚 Documentation preview 📚: https://read-the-docs-website--250.com.readthedocs.build/

<!-- readthedocs-preview read-the-docs-website end -->