### PR TITLE
Fix article image alt attribute

### DIFF
--- a/readthedocs_theme/templates/article.html
+++ b/readthedocs_theme/templates/article.html
@@ -53,7 +53,7 @@
 
       <div class="ui divider"></div>
 
-      <img class="ui big rounded centered image" src="{{ article.image or '/images/posts/default.svg' }}" alt="{{ article.image }}">
+      <img class="ui big rounded centered image" src="{{ article.image or '/images/posts/default.svg' }}" alt="{{ article.image_credit|striptags }}">
       {% if article.image and article.image_credit %}
         <div class="ui basic center aligned segment">
           <p><i>{{ article.image_credit}}</i></p>

--- a/readthedocs_theme/templates/index.html
+++ b/readthedocs_theme/templates/index.html
@@ -8,7 +8,7 @@
 {% macro article_card(article) %}
   <a class="ui card" href="/{{ article.url }}">
     <div class="image">
-      <img src="{{ article.image  or '/images/posts/default.svg'}}" alt="{{ article.image }}">
+      <img src="{{ article.image  or '/images/posts/default.svg'}}" alt="{{ article.image_credit|striptags }}">
     </div>
       <div class="content">
       <div class="header">{{ article.title }}</div>


### PR DESCRIPTION
PR #252 dropped the alt text to support HTML in the image credits, but a
more accessible fix here is just strip the HTML from the image credits
when using the credits in the attribute.

<!-- readthedocs-preview read-the-docs-website start -->
----
📚 Documentation preview 📚: https://read-the-docs-website--253.com.readthedocs.build/

<!-- readthedocs-preview read-the-docs-website end -->