### PR TITLE
Fix site url

### DIFF
--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -12,7 +12,7 @@ if os.environ.get("READTHEDOCS_VERSION_TYPE") == "external":
     SITEURL = ""
 else:
     # This setting is needed to make the RSS/Atom feeds generate correctly
-    SITEURL = "https://https://about.readthedocs.com"
+    SITEURL = "https://about.readthedocs.com"
 
 TIMEZONE = 'US/Pacific'
 DEFAULT_LANG = 'en'


### PR DESCRIPTION
Missed this typo in review at #254

<!-- readthedocs-preview read-the-docs-website start -->
----
📚 Documentation preview 📚: https://read-the-docs-website--257.com.readthedocs.build/

<!-- readthedocs-preview read-the-docs-website end -->