### PR TITLE
Use filename as slug source

### DIFF
--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -68,6 +68,7 @@ ARTICLE_PATHS = ['posts']
 STATIC_PATHS = ['images']
 
 # URL settings
+SLUGIFY_SOURCE = "basename"
 PAGE_URL = '{slug}/'
 PAGE_SAVE_AS = '{slug}/index.html'
 ARTICLE_URL = 'blog/{date:%Y}/{date:%m}/{slug}/'


### PR DESCRIPTION
By default, the title of the article is used as the slug, if the title is changed, the slug will be updated, and the URL of the article will be changed, leading to a 404.

Our previous blog used the filename as the slug, I like that.

If we agree, I can set slug explicitly for the articles that are already published or maybe create a redirect.

<!-- readthedocs-preview read-the-docs-website start -->
----
📚 Documentation preview 📚: https://read-the-docs-website--261.com.readthedocs.build/

<!-- readthedocs-preview read-the-docs-website end -->