### PR TITLE
Don't use relative URLs when deploying

### DIFF
--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -4,15 +4,15 @@ import os
 
 AUTHOR = 'Read the Docs, Inc'
 SITENAME = 'Read the Docs'
-RELATIVE_URLS = True
 
-if os.environ.get("READTHEDOCS_VERSION_TYPE") == "external":
-    # Make all URLs "domainless" in the RTD PR preview
-    # https://docs.readthedocs.io/en/stable/reference/environment-variables.html
-    SITEURL = ""
-else:
-    # This setting is needed to make the RSS/Atom feeds generate correctly
-    SITEURL = "https://about.readthedocs.com"
+# Use relavitve URLs for local development only.
+if not os.environ.get("READTHEDOCS"):
+    RELATIVE_URLS = True
+
+# Use the correct domain for the site URL (canonical or PR preview),
+# this setting is needed to make the RSS/Atom feeds generate correctly
+# https://docs.readthedocs.io/en/stable/reference/environment-variables.html.
+SITEURL = os.environ.get("READTHEDOCS_CANONICAL_URL", "")
 
 TIMEZONE = 'US/Pacific'
 DEFAULT_LANG = 'en'


### PR DESCRIPTION
See https://docs.getpelican.com/en/latest/settings.html?highlight=RELATIVE_URLS#url-settings.

This should be used when developing locally only.

Closes https://github.com/readthedocs/website/issues/226

<!-- readthedocs-preview read-the-docs-website start -->
----
📚 Documentation preview 📚: https://read-the-docs-website--263.com.readthedocs.build/

<!-- readthedocs-preview read-the-docs-website end -->