### PR TITLE
Fix "because we ❤️ documentation" FA icon

### DIFF
--- a/content/pages/company.html
+++ b/content/pages/company.html
@@ -192,7 +192,7 @@
           <div class="ui segment basic">
             <h3 class="ui header">Our docs</h3>
             <p>
-              The docs is where you'll find in-depth documentation about Read the Docs. From <i>"How to"</i> style guides to common usages, troubleshooting and advanced knowledge on how to work with our application, you'll find it all and probably more — <i>because we</i> <small><i class="fas fa-heart red icon"></i></small> <i>documentation</i> — in <a href="https://docs.readthedocs.io/">our docs</a>.
+              The docs is where you'll find in-depth documentation about Read the Docs. From <i>"How to"</i> style guides to common usages, troubleshooting and advanced knowledge on how to work with our application, you'll find it all and probably more — <i>because we</i> <small><i class="fas fa-heart red icon" aria-hidden="true"></i></small> <i>documentation</i> — in <a href="https://docs.readthedocs.io/">our docs</a>.
             </p>
           </div>
         </div>

--- a/content/pages/company.html
+++ b/content/pages/company.html
@@ -226,7 +226,7 @@
       <div class="ui basic vertical segment center aligned">
         <p>
           Want to display our logo in your project?<br>
-          Download our brand assets and learn how to use them in our <a href="https://read-the-docs-guidelines.readthedocs-hosted.com/branding.html">brand guidelines</a>
+          Download our brand assets and learn how to use them in our <a href="https://brand-guidelines.readthedocs.org/branding.html">brand guidelines</a>
         </p>
       </div>
 

--- a/content/pages/company.html
+++ b/content/pages/company.html
@@ -192,7 +192,7 @@
           <div class="ui segment basic">
             <h3 class="ui header">Our docs</h3>
             <p>
-              The docs is where you'll find in-depth documentation about Read the Docs. From <i>"How to"</i> style guides to common usages, troubleshooting and advanced knowledge on how to work with our application, you'll find it all and probably more — <i>because we</i> <small><i class="ui icon heart"></i></small> <i>documentation</i> — in <a href="https://docs.readthedocs.io/">our docs</a>.
+              The docs is where you'll find in-depth documentation about Read the Docs. From <i>"How to"</i> style guides to common usages, troubleshooting and advanced knowledge on how to work with our application, you'll find it all and probably more — <i>because we</i> <small><i class="fas fa-heart red icon"></i></small> <i>documentation</i> — in <a href="https://docs.readthedocs.io/">our docs</a>.
             </p>
           </div>
         </div>


### PR DESCRIPTION
Probably overlooked or not updated to the current markup.

Fixes `fas heart` icon inside a sentence.
\+ removes from ARIA roles
\+ updates branding link

![Screen Shot 2024-03-16 at 2 14 29](https://github.com/readthedocs/website/assets/1784648/682edf71-baf0-454c-97bd-dcf777e8ef55)


<!-- readthedocs-preview readthedocs-about start -->
----
📚 Documentation preview 📚: https://readthedocs-about--276.org.readthedocs.build/

<!-- readthedocs-preview readthedocs-about end -->