### PR TITLE
Remove "external link" icon on blog, and put it at top of resources

### DIFF
--- a/readthedocs_theme/templates/includes/topnav.html
+++ b/readthedocs_theme/templates/includes/topnav.html
@@ -51,7 +51,7 @@
 {% macro menu_resources() %}
 
   <div class="header">Updates</div>
-  <a class="item" href="{{ SITEURL }}/blog/" target="_blank">
+  <a class="item" href="{{ SITEURL }}/blog/">
     <i class="fad fa-newspaper fa-swap-opacity primary icon"></i>
     Blog
   </a>

--- a/readthedocs_theme/templates/includes/topnav.html
+++ b/readthedocs_theme/templates/includes/topnav.html
@@ -49,6 +49,31 @@
 
 {# Resources menu for secondary information and pages for search ranking #}
 {% macro menu_resources() %}
+
+  <div class="header">Updates</div>
+  <a class="item" href="{{ SITEURL }}/blog/" target="_blank">
+    <i class="fad fa-newspaper fa-swap-opacity primary icon"></i>
+    Blog
+  </a>
+  <a class="item" href="http://status.readthedocs.com" target="_blank">
+    {% block menu_help_status %}
+      {% if has_status_check %}
+        {# TODO get some data from status page API to light this up #}
+        <i class="fad fa-circle-check green icon"></i>
+        Status
+        <span class="description">
+          <span class="ui green text">Online</span>
+        </span>
+      {% else %}
+        <i class="fad fa-circle-check fa-swap-opacity primary icon"></i>
+        Status
+        <span class="description">
+          <i class="fad fa-external-link icon"></i>
+        </span>
+      {% endif %}
+    {% endblock menu_help_status %}
+  </a>
+
   <div class="header">Help</div>
   <a class="item" href="https://docs.readthedocs.io/page/support.html" target="_blank">
     <i class="fad fa-envelope primary icon"></i>
@@ -72,32 +97,6 @@
     </span>
   </a>
 
-  <div class="header">Updates</div>
-  <a class="item" href="{{ SITEURL }}/blog/" target="_blank">
-    <i class="fad fa-newspaper fa-swap-opacity primary icon"></i>
-    Blog
-    <span class="description">
-      <i class="fad fa-external-link icon"></i>
-    </span>
-  </a>
-  <a class="item" href="http://status.readthedocs.com" target="_blank">
-    {% block menu_help_status %}
-      {% if has_status_check %}
-        {# TODO get some data from status page API to light this up #}
-        <i class="fad fa-circle-check green icon"></i>
-        Status
-        <span class="description">
-          <span class="ui green text">Online</span>
-        </span>
-      {% else %}
-        <i class="fad fa-circle-check fa-swap-opacity primary icon"></i>
-        Status
-        <span class="description">
-          <i class="fad fa-external-link icon"></i>
-        </span>
-      {% endif %}
-    {% endblock menu_help_status %}
-  </a>
 {% endmacro %}
 
 {# Application links to log in #}


### PR DESCRIPTION


<!-- readthedocs-preview readthedocs-about start -->
----
📚 Documentation preview 📚: https://readthedocs-about--283.org.readthedocs.build/

<!-- readthedocs-preview readthedocs-about end -->