### PR TITLE
Fix casing on enterprise form

### DIFF
--- a/content/pages/enterprise.html
+++ b/content/pages/enterprise.html
@@ -26,11 +26,11 @@
 
   <section>
     {% call basic.header_lead(
-    header="Read the Docs is the <em><strong>all-in-one</strong></em> solution for Enterprise software documentation")
+    header="Read the Docs is the <em><strong>all-in-one</strong></em> solution for enterprise software documentation")
     %}
     <p>
       If your organization has specific needs that aren't met by our self-serve plans,
-      we offer Enterprise plans that can be customized to your requirements.
+      we offer enterprise plans that can be customized to your requirements.
     </p>
     <p class="ui center aligned basic segment">
       <a class="ui large teal button" href="/pricing/enterprise/#enterprise-inquiry">Tell us about your requirements</a>
@@ -71,7 +71,7 @@
         our <em>forever audit logs and analytics data</em> can help.
         {% endcall %}
 
-        {% call homepage.feature_detail_item(header="Custom Integrations", icon="fad fa-lightbulb") %}
+        {% call homepage.feature_detail_item(header="Custom integrations", icon="fad fa-lightbulb") %}
         Have additional needs that we haven't addressed here?
         We're happy to work with your team to work with additional requirements you have,
         tell us about them below.
@@ -92,7 +92,7 @@
         <form method="POST" name="fa-form-1" class="ui inverted form"
           action="https://webhook.frontapp.com/forms/036c4169294f3b04abaa/Jd5Qy6b7AYZHFZ-iHZ9OtRFlYyZqTGhYZEYBmrsrhHaiRaYLlKHF9nqccJg7pewDwFUbEZ0klqlNdSs7BcUAoJO7aPapcC7JQBlYV5S1GZ04oPvbkzVvriejZRY"
           enctype="multipart/form-data" accept-charset="utf-8">
-          <h2 class="ui center aligned dividing header">Talk with a sales rep about an Enterprise plan</h2>
+          <h2 class="ui center aligned dividing header">Talk with a sales rep about an enterprise plan</h2>
           <p>
             Let us know what you're looking for and we'll work with you to find the right solution.
           </p>
@@ -112,7 +112,7 @@
             <label>What type of documentation are you interested in?</label>
             <select class="ui dropdown" name="documentation-type">
               <option value="">Select type of documentation</option>
-              <option value="Internal Docs">Internal team documentation</option>
+              <option value="Internal docs">Internal team documentation</option>
               <option value="Public docs">Public product documentation</option>
               <option value="Open source docs">Open source project documentation</option>
               <option value="Other docs">Something else (explain below)</option>


### PR DESCRIPTION
I noticed a couple issues on casing, mainly "Enterprise" isn't a proper
noun and doesn't need to be capitalized.

<!-- readthedocs-preview readthedocs-about start -->
----
📚 Documentation preview 📚: https://readthedocs-about--303.org.readthedocs.build/

<!-- readthedocs-preview readthedocs-about end -->