### PR TITLE
Point community to new dashboard

### DIFF
--- a/content/pages/choosing-a-platform.rst
+++ b/content/pages/choosing-a-platform.rst
@@ -35,7 +35,7 @@ Important points:
 .. raw:: html
 
    <div class="ui basic center aligned padded segment">
-     <a class="ui teal button" href="https://readthedocs.org/accounts/signup/" data-analytics="community-signup">Sign up for a free community account</a>
+     <a class="ui teal button" href="https://app.readthedocs.org/accounts/signup/" data-analytics="community-signup">Sign up for a free community account</a>
    </div>
 
 

--- a/content/pages/pricing.html
+++ b/content/pages/pricing.html
@@ -203,7 +203,7 @@
       </div>
 
       <div class="ui basic center aligned padded segment">
-        <a class="ui teal button" href="https://readthedocs.org/accounts/signup/" data-analytics="community-signup">Sign up for a free community account</a>
+        <a class="ui teal button" href="https://app.readthedocs.org/accounts/signup/" data-analytics="community-signup">Sign up for a free community account</a>
       </div>
 
       {% block pricing_business_callout %}

--- a/content/pages/privacy-policy.rst
+++ b/content/pages/privacy-policy.rst
@@ -105,7 +105,7 @@ Why do we collect this information?
 - We limit our use of your User Personal Information to the purposes listed in this Privacy Statement.
   If we need to use your User Personal Information for other purposes, we will ask your permission first.
   You can always see what information we have in your
-  `user account <https://readthedocs.org/accounts/edit/>`__.
+  `user account <https://app.readthedocs.org/accounts/edit/>`__.
 
 What information Read the Docs does not collect
 -----------------------------------------------
@@ -177,8 +177,8 @@ or become a subscriber to Read the Docs' commercial hosting product,
 your payment information and details will be processed by Stripe.
 Read the Docs does not store your payment information.
 
-.. _Gold membership: https://readthedocs.org/accounts/gold/
-.. _Supporter: https://readthedocs.org/sustainability/
+.. _Gold membership: https://app.readthedocs.org/accounts/gold/
+.. _Supporter: https://app.readthedocs.org/sustainability/
 
 Site monitoring
 +++++++++++++++
@@ -371,7 +371,7 @@ How you can access and control the information we collect
 
 If you're already a Read the Docs user, you may access, update, alter,
 or delete your basic user profile information by
-`editing your user account <https://readthedocs.org/accounts/edit/>`__.
+`editing your user account <https://app.readthedocs.org/accounts/edit/>`__.
 
 
 Data retention and deletion
@@ -387,7 +387,7 @@ so unless you choose to delete your account,
 we will retain your account information indefinitely.
 
 If you would like to delete your User Personal Information,
-you may do so in your `user account <https://readthedocs.org/accounts/delete/>`__.
+you may do so in your `user account <https://app.readthedocs.org/accounts/delete/>`__.
 We will retain and use your information as necessary to comply with
 our legal obligations, resolve disputes, and enforce our agreements,
 but barring legal requirements, we will delete your full profile.

--- a/content/posts/drop-support-for-subversion-mercurial-bazaar.md
+++ b/content/posts/drop-support-for-subversion-mercurial-bazaar.md
@@ -77,5 +77,5 @@ if you want to trigger a build each time a push is done to the original reposito
 
 ## Contact us
 
-[Contact us](https://readthedocs.org/support/) if you have any questions,
+[Contact us](https://app.readthedocs.org/support/) if you have any questions,
 and let us know any inconvenient you may have with this change.

--- a/content/posts/enable-beta-addons.md
+++ b/content/posts/enable-beta-addons.md
@@ -134,5 +134,5 @@ and much more in near future!
 
 ## Contact
 
-[Contact us](https://readthedocs.org/support/) if you have any questions about the new beta Read the Docs Addons,
+[Contact us](https://app.readthedocs.org/support/) if you have any questions about the new beta Read the Docs Addons,
 or [open an issue](https://github.com/readthedocs/addons) to share any feedback you may have.

--- a/content/posts/mkdocs-yaml-manipulation.md
+++ b/content/posts/mkdocs-yaml-manipulation.md
@@ -23,5 +23,5 @@ This simplification allows more complex configuration in the YAML by using the s
 [that wasn't previously supported due to security reasons](https://github.com/readthedocs/readthedocs.org/issues/8529).
 
 
-[Contact us](https://readthedocs.org/support/) if you have any questions,
+[Contact us](https://app.readthedocs.org/support/) if you have any questions,
 and let us know any inconvenient you may have with this change.

--- a/content/posts/read-the-docs-2023-stats.rst
+++ b/content/posts/read-the-docs-2023-stats.rst
@@ -20,7 +20,7 @@ and we're excited to continue providing a world-class documentation platform and
 
 	Our posts from 2013_, 2014_, 2015_, 2016_, 2017_, 2018_, 2019_, 2020_, 2021_ are also available.
 
-.. _Read the Docs: https://readthedocs.org/
+.. _Read the Docs: https://app.readthedocs.org/
 .. _30 days: http://www.seethestats.com/site/readthedocs.org
 .. _2013: https://blog.readthedocs.com/read-the-docs-2013-stats/
 .. _2014: https://blog.readthedocs.com/read-the-docs-2014-stats/

--- a/content/posts/readme-html-deprecated.md
+++ b/content/posts/readme-html-deprecated.md
@@ -36,5 +36,5 @@ Note these are only two possible ideas, but there may be other ways to achieve t
 
 > _**Tip**: you can create a redirect from `/README.html` to `/` to keep links pointing to the deprecated URL working._
 
-[Contact us](https://readthedocs.org/support/) if you have any questions,
+[Contact us](https://app.readthedocs.org/support/) if you have any questions,
 and let us know any inconvenient you may have with this change.

--- a/examples/mockups/index.html
+++ b/examples/mockups/index.html
@@ -260,7 +260,7 @@
               <h4 class="ui sub header">Business Info</h4>
     
               <div class="ui list">
-                <a class="item" href="{{ advertising_url | default:'https://readthedocs.org/sustainability/advertising/' }}">Advertise with Us</a>
+                <a class="item" href="{{ advertising_url | default:'https://app.readthedocs.org/sustainability/advertising/' }}">Advertise with Us</a>
                 <a class="item" href="https://readthedocs.com">Read the Docs for Business</a>
                 <a class="item" href='{{ donate_url }}'>Supporters</a>
                 <a class="item" href="https://docs.readthedocs.io/page/privacy-policy.html">Privacy Policy</a>

--- a/examples/mockups/pricing.html
+++ b/examples/mockups/pricing.html
@@ -589,7 +589,7 @@
               <h4 class="ui sub header">Business Info</h4>
     
               <div class="ui list">
-                <a class="item" href="{{ advertising_url | default:'https://readthedocs.org/sustainability/advertising/' }}">Advertise with Us</a>
+                <a class="item" href="{{ advertising_url | default:'https://app.readthedocs.org/sustainability/advertising/' }}">Advertise with Us</a>
                 <a class="item" href="https://readthedocs.com">Read the Docs for Business</a>
                 <a class="item" href='{{ donate_url }}'>Supporters</a>
                 <a class="item" href="https://docs.readthedocs.io/page/privacy-policy.html">Privacy Policy</a>

--- a/examples/mockups/product.html
+++ b/examples/mockups/product.html
@@ -333,7 +333,7 @@
               <h4 class="ui sub header">Business Info</h4>
     
               <div class="ui list">
-                <a class="item" href="{{ advertising_url | default:'https://readthedocs.org/sustainability/advertising/' }}">Advertise with Us</a>
+                <a class="item" href="{{ advertising_url | default:'https://app.readthedocs.org/sustainability/advertising/' }}">Advertise with Us</a>
                 <a class="item" href="https://readthedocs.com">Read the Docs for Business</a>
                 <a class="item" href='{{ donate_url }}'>Supporters</a>
                 <a class="item" href="https://docs.readthedocs.io/page/privacy-policy.html">Privacy Policy</a>

--- a/readthedocs_theme/templates/includes/topnav.html
+++ b/readthedocs_theme/templates/includes/topnav.html
@@ -111,7 +111,7 @@
     Read the Docs Community
 
     <p class="ui mini grey text">
-      <code>https://app.readthedocs.org</code>
+      <code>https://readthedocs.org</code>
     </p>
   </a>
   <a class="item" data-analytics="commercial-login" href="https://readthedocs.com/dashboard/">

--- a/readthedocs_theme/templates/includes/topnav.html
+++ b/readthedocs_theme/templates/includes/topnav.html
@@ -106,12 +106,12 @@
 {# Application links to log in #}
 {% macro menu_log_in(with_signup=False) %}
   <div class="header">Log in</div>
-  <a class="item" data-analytics="community-login" href="https://readthedocs.org/dashboard/">
+  <a class="item" data-analytics="community-login" href="https://app.readthedocs.org/dashboard/">
     <i class="fad fa-people-group primary icon"></i>
     Read the Docs Community
 
     <p class="ui mini grey text">
-      <code>https://readthedocs.org</code>
+      <code>https://app.readthedocs.org</code>
     </p>
   </a>
   <a class="item" data-analytics="commercial-login" href="https://readthedocs.com/dashboard/">
@@ -292,7 +292,7 @@
 
                 <a class="ui primary center aligned button"
                   data-analytics="community-signup"
-                   href="https://readthedocs.org/accounts/signup/">
+                   href="https://app.readthedocs.org/accounts/signup/">
                   Sign up
                 </a>
               </div>


### PR DESCRIPTION
We are already migrated on community, so I think we can start pointing people to the new dashboard already.

<!-- readthedocs-preview readthedocs-about start -->
----
📚 Documentation preview 📚: https://readthedocs-about--332.org.readthedocs.build/

<!-- readthedocs-preview readthedocs-about end -->