### PR TITLE
fix(jekyll): fix bundler package name

### DIFF
--- a/content/posts/read-the-docs-loves-ruby.md
+++ b/content/posts/read-the-docs-loves-ruby.md
@@ -25,7 +25,7 @@ build:
   tools:
     ruby: "3.3"
   commands:
-    - gem install bundle
+    - gem install bundler
     - bundle install
     - jekyll build --destination $READTHEDOCS_OUTPUT/html
 ```


### PR DESCRIPTION
The correct package is `bundler` not `bundle`.

I also made a PR here: https://github.com/readthedocs/ext-theme/pull/574