### PR TITLE
Add link to Community plans to make them more obvious

### DIFF
--- a/readthedocs_theme/templates/includes/topnav.html
+++ b/readthedocs_theme/templates/includes/topnav.html
@@ -29,9 +29,13 @@
 {# Pricing menu for plans and enterprise #}
 {% macro menu_pricing() %}
   <div class="header">Plans</div>
-  <a class="item" href="{{ SITEURL }}/pricing/">
+  <a class="item" href="{{ SITEURL }}/pricing/#/business">
     <i class="fad fa-diagram-venn primary icon"></i>
-    Standard plans
+    Business plans
+  </a>
+  <a class="item" href="{{ SITEURL }}/pricing/#/community">
+    <i class="fad fa-diagram-venn primary icon"></i>
+    Community plans
   </a>
   <a class="item" href="{{ SITEURL }}/pricing/enterprise/">
     <i class="fad fa-briefcase primary icon"></i>
@@ -105,7 +109,7 @@
   </a>
   <a class="item" data-analytics="commercial-login" href="https://app.readthedocs.com/dashboard/">
     <i class="fad fa-building secondary icon"></i>
-    Read the Docs for Business
+    Read the Docs Business
 
     <p class="ui mini grey text">
       <code>https://readthedocs.com</code>
@@ -302,7 +306,7 @@
           <div class="seven wide computer sixteen wide tablet column">
             <div class="ui raised segment">
               <div class="ui header">
-                Read the Docs for Business
+                Read the Docs Business
                 <div class="sub header">
                   For commercial and non-free projects
                 </div>


### PR DESCRIPTION
I think this is a nice change to highlight Community. I've seen some rumbling of us not supporting Community anymore, so I think highlighting them like this is good.

I'd love to have the `Pricing` topnav item also be a link, but when I link it, it gets some weird styling that I couldn't easily fix. 

<img width="333" alt="Screenshot 2025-03-26 at 8 43 49 AM" src="https://github.com/user-attachments/assets/5a8b0720-f06f-49ea-9a16-0e6eeae3e7f3" />

<!-- readthedocs-preview readthedocs-about start -->
----
📚 Documentation preview 📚: https://readthedocs-about--353.org.readthedocs.build/

<!-- readthedocs-preview readthedocs-about end -->