### PR TITLE
content: refresh the about us page

### DIFF
--- a/content/pages/company.html
+++ b/content/pages/company.html
@@ -209,7 +209,7 @@
             <h3 class="ui header">Our newsletter</h3>
             <p>
               <a href="https://landing.mailerlite.com/webforms/landing/t0a9l4">Subscribe</a>
-              to get a monthly update on what we're building, in your inbox.
+              to get updates on what we're building, in your inbox.
             </p>
           </div>
         </div>
@@ -229,7 +229,6 @@
       </h1>
       <div class="ui basic vertical segment center aligned">
         <p>
-          Want to display our logo in your project?<br>
           Download our logos and learn how to use them in our <a href="https://brand-guidelines.readthedocs.org/branding.html">brand guidelines</a>.
         </p>
       </div>

--- a/content/pages/company.html
+++ b/content/pages/company.html
@@ -1,7 +1,7 @@
 <html>
   <head>
     <meta name="title" content="About us" />
-    <meta name="description" content="Read the Docs has been building and hosting documentation for open source projects since 2010. Meet the team behind the platform." />
+    <meta name="description" content="Read the Docs has been building and hosting documentation for open source projects since 2010, and for companies since 2014. Meet the team behind the platform." />
     <meta name="template" content="page" />
     <meta name="slug" content="company" />
     <meta name="status" content="hidden" />
@@ -20,7 +20,8 @@
           </h1>
           <div class="ui basic vertical huge segment center aligned">
             <p>
-              We've been building and hosting documentation for open source projects since 2010.
+              We've been building and hosting documentation for open source projects since 2010,
+              and for companies since 2014.
               Read the Docs is open source and independent,
               run by a small team with help from our community.
             </p>

--- a/content/pages/company.html
+++ b/content/pages/company.html
@@ -61,7 +61,7 @@
               Every month we serve over 250 million pageviews and run over 350,000 documentation builds.
             </p>
             <p>
-              See <a href="https://about.readthedocs.com/blog/2025/09/aws-powers-read-the-docs/">how we run it</a>,
+              See <a href="{{ SITEURL }}/blog/2025/09/aws-powers-read-the-docs/">how we run it</a>,
               on infrastructure graciously provided by <a href="https://aws.amazon.com/">AWS</a>.
             </p>
           </div>
@@ -188,7 +188,7 @@
             <h3 class="ui header">Our blog</h3>
             <p>
               We post product updates and announcements on
-              <a href="https://blog.readthedocs.com/">our blog</a>.
+              <a href="{{ SITEURL }}/blog/">our blog</a>.
             </p>
           </div>
         </div>

--- a/content/pages/company.html
+++ b/content/pages/company.html
@@ -22,8 +22,8 @@
             <p>
               We've been building and hosting documentation for open source projects since 2010,
               and for companies since 2014.
-              Read the Docs is open source and independent,
-              run by a small team with help from our community.
+              Read the Docs is run by a small team and mostly bootstrapped —
+              companies paying for private documentation hosting are what fund the free community site.
             </p>
           </div>
         </div>
@@ -44,9 +44,11 @@
           <div class="ui basic segment center aligned">
             <h3 class="ui header big">Mission</h3>
             <p>
-              Documentation should be part of every development workflow.
-              We build the tools to write, build, and host your docs directly from your Git repository,
-              so updating documentation is as simple as merging a pull request.
+              Read the Docs was founded to improve documentation in the open source community.
+              Our vision is to be the best place to host software documentation using a docs-as-code approach.
+            </p>
+            <p>
+              We build on top of Git, so your documentation ships the same way your code does.
             </p>
           </div>
         </div>
@@ -58,6 +60,10 @@
               What started as a weekend project now hosts documentation for over 100,000 open source projects.
               Every month we serve over 250 million pageviews and run over 350,000 documentation builds.
             </p>
+            <p>
+              See <a href="https://about.readthedocs.com/blog/2025/09/aws-powers-read-the-docs/">how we run it</a>,
+              on infrastructure graciously provided by <a href="https://aws.amazon.com/">AWS</a>.
+            </p>
           </div>
         </div>
 
@@ -65,11 +71,12 @@
           <div class="ui basic segment center aligned">
             <h3 class="ui header big">Community</h3>
             <p>
-              Read the Docs depends on users like you for development, support, and funding.
-              Learn how to <a href="https://docs.readthedocs.io/page/contribute.html">contribute</a> in our documentation.
+              Read the Docs is open source and community supported.
+              It depends on people like you contributing to development, support, and operations.
             </p>
             <p>
-              Hosting for the project is graciously provided by <a href="https://aws.amazon.com/">AWS</a>.
+              Learn how to <a href="https://docs.readthedocs.com/dev/latest/contribute.html">contribute</a>,
+              and thanks to our <a href="https://docs.readthedocs.com/platform/stable/team.html">community team</a> who help us run the site.
             </p>
           </div>
         </div>
@@ -192,7 +199,7 @@
             <p>
               Everything about using Read the Docs,
               from getting started to advanced guides,
-              lives in <a href="https://docs.readthedocs.io/">our documentation</a>.
+              lives in <a href="https://docs.readthedocs.com/platform/stable/">our documentation</a>.
             </p>
           </div>
         </div>

--- a/content/pages/company.html
+++ b/content/pages/company.html
@@ -1,7 +1,7 @@
 <html>
   <head>
     <meta name="title" content="About us" />
-    <meta name="description" content="Read the Docs is an open source project providing the tools, knowledge, and hosting for some of the world's top documentation teams." />
+    <meta name="description" content="Read the Docs has been building and hosting documentation for open source projects since 2010. Meet the team behind the platform." />
     <meta name="template" content="page" />
     <meta name="slug" content="company" />
     <meta name="status" content="hidden" />
@@ -16,11 +16,13 @@
 
         <div class="column twelve wide computer twelve wide tablet sixteen wide mobile">
           <h1 class="ui header massive center aligned">
-            <span class="ui header big">Read the Docs: Documentation Simplified</span>
+            About Read the Docs
           </h1>
           <div class="ui basic vertical huge segment center aligned">
             <p>
-              We are an open source project providing the tools, knowledge and hosting for some of the world's top documentation teams.
+              We've been building and hosting documentation for open source projects since 2010.
+              Read the Docs is open source and independent,
+              run by a small team with help from our community.
             </p>
           </div>
         </div>
@@ -41,23 +43,20 @@
           <div class="ui basic segment center aligned">
             <h3 class="ui header big">Mission</h3>
             <p>
-              Technical teams rely on up-to-date documentation and require solid methods and tools to help creating continuous documentation that will improve team efficiency and productivity.
-            </p>
-            <p>
-              Our mission is to develop those tools and help shape the methods that will make high-quality documentation part of the normal development workflow.
+              Documentation should be part of every development workflow.
+              We build the tools to write, build, and host your docs directly from your Git repository,
+              so updating documentation is as simple as merging a pull request.
             </p>
           </div>
         </div>
 
         <div class="column">
           <div class="ui basic segment center aligned">
-            <h3 class="ui header big">Growth</h3>
+            <h3 class="ui header big">Scale</h3>
             <p>
-              Read the Docs has grown substantially since its beginning as a weekend project and is closing in on being a top-1000 site on the internet.
+              What started as a weekend project now hosts documentation for over 100,000 open source projects.
+              Every month we serve over 250 million pageviews and run over 350,000 documentation builds.
             </p>
-            <p>Today, we serve over 55 million pages of documentation a month,
-              serve over 40 TB of documentation a month,
-              host over 80,000 open source projects and support over 100,000 users</p>
           </div>
         </div>
 
@@ -65,9 +64,8 @@
           <div class="ui basic segment center aligned">
             <h3 class="ui header big">Community</h3>
             <p>
-              Read the Docs is open source and community supported. It depends on users like you to contribute to development, support, and operations. You can learn more about how to <a href="https://docs.readthedocs.io/page/contribute.html">contribute</a> in our
-              docs. Thanks so much to our wonderful <a href="https://docs.readthedocs.io/page/team.html">community team</a> who helps us
-              run the site. Read the Docs wouldn't be possible without them.
+              Read the Docs depends on users like you for development, support, and funding.
+              Learn how to <a href="https://docs.readthedocs.io/page/contribute.html">contribute</a> in our documentation.
             </p>
             <p>
               Hosting for the project is graciously provided by <a href="https://aws.amazon.com/">AWS</a>.
@@ -96,7 +94,7 @@
 
           <div class="card borderless">
             <div class="image">
-              <img alt="Contributor"  src="/theme/img/team/eric.jfif">
+              <img alt="Eric Holscher" src="/theme/img/team/eric.jfif">
             </div>
             <div class="content">
               <div class="header">Eric Holscher</div>
@@ -105,7 +103,7 @@
 
           <div class="card borderless">
             <div class="image">
-              <img alt="Contributor"  src="/theme/img/team/anthony.jfif">
+              <img alt="Anthony Johnson" src="/theme/img/team/anthony.jfif">
             </div>
             <div class="content">
               <div class="header">Anthony Johnson</div>
@@ -114,7 +112,7 @@
 
           <div class="card borderless">
             <div class="image">
-              <img alt="Contributor"  src="/theme/img/team/manuel.jfif">
+              <img alt="Manuel Kaufmann" src="/theme/img/team/manuel.jfif">
             </div>
             <div class="content">
               <div class="header">Manuel Kaufmann</div>
@@ -123,7 +121,7 @@
 
           <div class="card borderless">
             <div class="image">
-              <img alt="Contributor"  src="/theme/img/team/santos.jfif">
+              <img alt="Santos Gallegos" src="/theme/img/team/santos.jfif">
             </div>
             <div class="content">
               <div class="header">Santos Gallegos</div>
@@ -142,23 +140,23 @@
             <div class="ui grid relaxed stackable">
               <div class="five wide column">
                 <div class="ui mini circular overlapping images">
-                  <a href="https://github.com/Blendify" title="Blendify"><img alt="Contributor"  class="ui image" src="/theme/img/contributors/Blendify.jpg"></a>
-                  <a href="https://github.com/jessetan" title="jessetan"><img alt="Contributor"  class="ui image" src="/theme/img/contributors/jessetan.jpg"></a>
-                  <a href="https://github.com/saadmk11" title="saadmk11"><img alt="Contributor"  class="ui image" src="/theme/img/contributors/saadmk11.jpg"></a>
-                  <a href="https://github.com/dojutsu-user" title="dojutsu-user"><img alt="Contributor"  class="ui image" src="/theme/img/contributors/dojutsu-user.jpg"></a>
-                  <a href="https://github.com/safwanrahman" title="safwanrahman"><img alt="Contributor"  class="ui image" src="/theme/img/contributors/safwanrahman.jpg"></a>
-                  <a href="https://github.com/tapaswenipathak" title="tapaswenipathak"><img alt="Contributor"  class="ui image" src="/theme/img/contributors/tapaswenipathak.jpg"></a>
-                  <a href="https://github.com/cocobennett" title="cocobennett"><img alt="Contributor"  class="ui image" src="/theme/img/contributors/cocobennett.jpg"></a>
-                  <a href="https://github.com/Blackcipher101" title="Blackcipher101"><img alt="Contributor"  class="ui image" src="/theme/img/contributors/Blackcipher101.jpg"></a>
-                  <a href="https://github.com/Abhi-khandelwal" title="Abhi-khandelwal"><img alt="Contributor"  class="ui image" src="/theme/img/contributors/Abhi-khandelwal.jpg"></a>
+                  <a href="https://github.com/Blendify" title="Blendify"><img alt="Blendify" class="ui image" src="/theme/img/contributors/Blendify.jpg"></a>
+                  <a href="https://github.com/jessetan" title="jessetan"><img alt="jessetan" class="ui image" src="/theme/img/contributors/jessetan.jpg"></a>
+                  <a href="https://github.com/saadmk11" title="saadmk11"><img alt="saadmk11" class="ui image" src="/theme/img/contributors/saadmk11.jpg"></a>
+                  <a href="https://github.com/dojutsu-user" title="dojutsu-user"><img alt="dojutsu-user" class="ui image" src="/theme/img/contributors/dojutsu-user.jpg"></a>
+                  <a href="https://github.com/safwanrahman" title="safwanrahman"><img alt="safwanrahman" class="ui image" src="/theme/img/contributors/safwanrahman.jpg"></a>
+                  <a href="https://github.com/tapaswenipathak" title="tapaswenipathak"><img alt="tapaswenipathak" class="ui image" src="/theme/img/contributors/tapaswenipathak.jpg"></a>
+                  <a href="https://github.com/cocobennett" title="cocobennett"><img alt="cocobennett" class="ui image" src="/theme/img/contributors/cocobennett.jpg"></a>
+                  <a href="https://github.com/Blackcipher101" title="Blackcipher101"><img alt="Blackcipher101" class="ui image" src="/theme/img/contributors/Blackcipher101.jpg"></a>
+                  <a href="https://github.com/Abhi-khandelwal" title="Abhi-khandelwal"><img alt="Abhi-khandelwal" class="ui image" src="/theme/img/contributors/Abhi-khandelwal.jpg"></a>
                 </div>
               </div>
               <div class="eleven wide column">
                 <p>
-                  We are honored to have several external contributors that have kept with us for a long time and helped us a lot along the way. Here we list just a few but the full list can be found at <a href="https://github.com/readthedocs/readthedocs.org/graphs/contributors">GitHub</a>.
-                </p>
-                <p>
-                  A heart felt thanks to all of you!
+                  Hundreds of contributors have helped build Read the Docs over the years.
+                  Here are a few who have been with us a long time,
+                  and the full list is on <a href="https://github.com/readthedocs/readthedocs.org/graphs/contributors">GitHub</a>.
+                  Thank you all.
                 </p>
               </div>
             </div>
@@ -181,32 +179,29 @@
           <div class="ui segment basic">
             <h3 class="ui header">Our blog</h3>
             <p>
-              This is where we post all our week-to-week progress updates and announcements.
-            </p>
-            <p>
-              <a href="https://blog.readthedocs.com/">Check it out!</a>
+              We post product updates and announcements on
+              <a href="https://blog.readthedocs.com/">our blog</a>.
             </p>
           </div>
         </div>
 
         <div class="column">
           <div class="ui segment basic">
-            <h3 class="ui header">Our docs</h3>
+            <h3 class="ui header">Our documentation</h3>
             <p>
-              The docs is where you'll find in-depth documentation about Read the Docs. From <i>"How to"</i> style guides to common usages, troubleshooting and advanced knowledge on how to work with our application, you'll find it all and probably more — <i>because we</i> <small><i class="fas fa-heart red icon" aria-hidden="true"></i></small> <i>documentation</i> — in <a href="https://docs.readthedocs.io/">our docs</a>.
+              Everything about using Read the Docs,
+              from getting started to advanced guides,
+              lives in <a href="https://docs.readthedocs.io/">our documentation</a>.
             </p>
           </div>
         </div>
 
         <div class="column">
           <div class="ui segment basic">
-            <h3 class="ui header">Subscribe to our newsletter</h3>
+            <h3 class="ui header">Our newsletter</h3>
             <p>
-              Every time we post a blog post,
-              you can get it in your inbox.
-            </p>
-            <p>
-              <a href="https://blog.readthedocs.com/">Subscribe now</a>
+              <a href="https://landing.mailerlite.com/webforms/landing/t0a9l4">Subscribe</a>
+              to get a monthly update on what we're building, in your inbox.
             </p>
           </div>
         </div>
@@ -222,12 +217,12 @@
     <div class="ui container">
 
       <h1 class="ui header massive center aligned">
-        Brand Assets
+        Brand assets
       </h1>
       <div class="ui basic vertical segment center aligned">
         <p>
           Want to display our logo in your project?<br>
-          Download our brand assets and learn how to use them in our <a href="https://brand-guidelines.readthedocs.org/branding.html">brand guidelines</a>
+          Download our logos and learn how to use them in our <a href="https://brand-guidelines.readthedocs.org/branding.html">brand guidelines</a>.
         </p>
       </div>
 


### PR DESCRIPTION
The about page had gone stale. The traffic and project numbers were several years old, and the mission copy had drifted into abstract positioning that doesn't match how we describe ourselves anywhere else.

Figures now come from the September 2025 AWS post, and the page links it so the numbers have a dated source to check against next time. The mission copy is lifted from things already on record — the vision statement from the 2025 vision post, the founding line from `open-source-philosophy.rst`, and the funding model from the 10-year anniversary post — rather than newly written.

Two links were broken rather than merely stale: the contribute link 404'd (it pointed into the user docs, but contribute lives in the dev docs), and the docs, team and blog links all went through legacy-domain redirects.

Worth confirming: the intro sentence about being bootstrapped and funded by Business customers is accurate, but blunter than we usually are in public. It's the one line here that's a positioning call rather than a correction.

The team section is unchanged.