### PR TITLE
theme: match mobile nav to desktop

### DIFF
--- a/readthedocs_theme/templates/includes/topnav.html
+++ b/readthedocs_theme/templates/includes/topnav.html
@@ -1,74 +1,3 @@
-{# Pricing menu for plans and enterprise #}
-{% macro menu_pricing() %}
-  <div class="header">Plans</div>
-  <a class="item" href="{{ SITEURL }}/pricing/#/business">
-    <i class="fad fa-diagram-venn primary icon"></i>
-    Business plans
-  </a>
-  <a class="item" href="{{ SITEURL }}/pricing/#/community">
-    <i class="fad fa-diagram-venn primary icon"></i>
-    Community plans
-  </a>
-  <a class="item" href="{{ SITEURL }}/pricing/enterprise/">
-    <i class="fad fa-briefcase primary icon"></i>
-    Enterprise plans
-  </a>
-{% endmacro %}
-
-{# Resources menu for secondary information and pages for search ranking #}
-{% macro menu_resources() %}
-
-  <div class="header">Updates</div>
-  <a class="item" href="{{ SITEURL }}/blog/">
-    <i class="fad fa-newspaper fa-swap-opacity primary icon"></i>
-    Blog
-  </a>
-
-  <div class="header">Help</div>
-  <a class="item" href="http://status.readthedocs.com" target="_blank">
-    {% block menu_help_status %}
-      {% if has_status_check %}
-        {# TODO get some data from status page API to light this up #}
-        <i class="fad fa-circle-check green icon"></i>
-        Status
-        <span class="description">
-          <span class="ui green text">Online</span>
-        </span>
-      {% else %}
-        <i class="fad fa-circle-check fa-swap-opacity primary icon"></i>
-        Status
-        <span class="description">
-          <i class="fad fa-external-link icon"></i>
-        </span>
-      {% endif %}
-    {% endblock menu_help_status %}
-  </a>
-
-  <a class="item" href="https://docs.readthedocs.io/page/support.html" target="_blank">
-    <i class="fad fa-envelope primary icon"></i>
-    Support
-    <span class="description">
-      <i class="fad fa-external-link icon"></i>
-    </span>
-  </a>
-  <a class="item" href="https://docs.readthedocs.io" target="_blank">
-    <i class="fad fa-book primary icon"></i>
-    Documentation
-    <span class="description">
-      <i class="fad fa-external-link icon"></i>
-    </span>
-  </a>
-  <a class="item" href="https://docs.readthedocs.io/page/tutorial/" target="_blank">
-    <i class="fad fa-rocket primary icon"></i>
-    Tutorial
-    <span class="description">
-      <i class="fad fa-external-link icon"></i>
-    </span>
-  </a>
-
-{% endmacro %}
-
-{# Application links to log in #}
 {% macro menu_log_in(with_signup=False) %}
   <div class="header">Log in</div>
   <a class="item" data-analytics="community-login" href="https://app.readthedocs.org/dashboard/">
@@ -126,16 +55,26 @@
             <i class="fad fa-bars large icon" style="--fa-secondary-opacity: 0.8;"></i>
             <div class="menu">
 
-              {{ menu_log_in(with_signup=True) }}
-              <div class="divider"></div>
               <a class="item" href="{{ SITEURL }}/features/">
                 <i class="fad fa-arrow-progress primary icon"></i>
                 Product
               </a>
+              <a class="item" href="{{ SITEURL }}/pricing/">
+                <i class="fad fa-diagram-venn primary icon"></i>
+                Pricing
+              </a>
+              <a class="item" href="{{ SITEURL }}/blog/">
+                <i class="fad fa-newspaper fa-swap-opacity primary icon"></i>
+                Blog
+              </a>
+              <a class="item" href="https://docs.readthedocs.io" target="_blank">
+                <i class="fad fa-book primary icon"></i>
+                Docs
+              </a>
+
               <div class="divider"></div>
-              {{ menu_pricing() }}
-              <div class="divider"></div>
-              {{ menu_resources() }}
+
+              {{ menu_log_in(with_signup=True) }}
 
             </div>
           </div>


### PR DESCRIPTION
Make nav match. I think we just missed this when we redid the desktop. 


<img width="525" height="531" alt="Screenshot 2026-08-21 at 11 39 47 AM" src="https://github.com/user-attachments/assets/9e438624-0358-47c4-9f3e-0f2a1f5faa4b" />


---
_Generated by [Claude Code](https://claude.ai/code/session_01Es5x6QDEf9fQGaBSkjTM4F)_