### PR TITLE
theme: keep the mobile nav menu on screen

### DIFF
--- a/readthedocs_theme/templates/includes/topnav.html
+++ b/readthedocs_theme/templates/includes/topnav.html
@@ -122,9 +122,13 @@
       #}
       {% block topnav_mobile_menu %}
         <div class="five wide mobile only right aligned column">
-          <div class="ui wide dropdown" data-module="dropdown" data-action="select">
+          <div class="ui dropdown" data-module="dropdown" data-action="select">
             <i class="fad fa-bars large icon" style="--fa-secondary-opacity: 0.8;"></i>
-            <div class="menu">
+            {# The trigger sits at the right edge of the viewport, so the menu
+               has to open leftwards from it. `left` right-aligns the menu to
+               the trigger; dropping `wide` lets it size to its content instead
+               of a fixed 320px, which does not fit a 320px viewport. #}
+            <div class="left menu">
 
               {{ menu_log_in(with_signup=True) }}
               <div class="divider"></div>

--- a/readthedocs_theme/templates/includes/topnav.html
+++ b/readthedocs_theme/templates/includes/topnav.html
@@ -51,12 +51,10 @@
       #}
       {% block topnav_mobile_menu %}
         <div class="five wide mobile only right aligned column">
-          <div class="ui dropdown" data-module="dropdown" data-action="select">
+          <div class="ui wide dropdown" data-module="dropdown" data-action="select">
             <i class="fad fa-bars large icon" style="--fa-secondary-opacity: 0.8;"></i>
             {# The trigger sits at the right edge of the viewport, so the menu
-               has to open leftwards from it. `left` right-aligns the menu to
-               the trigger; dropping `wide` lets it size to its content instead
-               of a fixed 320px, which does not fit a 320px viewport. #}
+               has to open leftwards from it. #}
             <div class="left menu">
 
               <a class="item" href="{{ SITEURL }}/features/">


### PR DESCRIPTION
The mobile nav menu opens off the right edge of the viewport — 273px past it, at every mobile width. Reported by @agjohnson in #439, but the markup predates that PR and it reproduces on the live site.

The menu carried no direction class, so Fomantic paints it from its trigger's left edge, and that trigger sits at the far right of the nav. It looks correct in practice only because the dropdown JS adds `left` on open and re-anchors it — so the correct position was never in the CSS, and anything that stops or delays module init leaves the broken state on screen. Putting `left` in the markup fixes it at first paint and matches what the JS was already doing, so the two don't fight.

Verified in Chromium at 320 / 360 / 390 / 430 / 500 / 600 / 700 / 767, each with the JS bundle both loaded and blocked, since the blocked case is the failure mode. No menu text is clipped at any of them. At 320px the menu's left edge sits 15px off-screen, but that margin is padding — the leftmost text lands at x=4 and stays readable.